### PR TITLE
Fix name of the bundle in metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,3 +1,1 @@
-# A requirement of ops_test, unrelated to building the bundle. To use ops_test, we have to have a
-# charm name that'll actually be deployed, so we're using postgres for now.
-name: postgresql-k8s
+name: postgresql-k8s-bundle

--- a/tests/integration/bundle/test_bundle.py
+++ b/tests/integration/bundle/test_bundle.py
@@ -89,7 +89,7 @@ async def test_kill_pg_primary(ops_test: OpsTest):
     connstr = finos_databag.get("master", None)
     assert connstr, f"databag incorrectly populated, \n {finos_databag}"
 
-    pgb_unit = get_leader(ops_test, PGB).name
+    pgb_unit = await get_leader(ops_test, PGB)
     pgb_unit_address = await get_unit_address(ops_test, pgb_unit)
     conn_dict = pgb.parse_kv_string_to_dict(connstr)
     conn_dict["host"] = pgb_unit_address
@@ -119,7 +119,7 @@ async def test_kill_pg_primary(ops_test: OpsTest):
     finos_databag = await get_app_relation_databag(ops_test, finos_unit_name, finos_relation.id)
     connstr = finos_databag.get("master", None)
     assert connstr, f"databag incorrectly populated: \n{finos_databag}"
-    pgb_unit = get_leader(ops_test, PGB).name
+    pgb_unit = await get_leader(ops_test, PGB)
     pgb_unit_address = await get_unit_address(ops_test, pgb_unit)
     conn_dict = pgb.parse_kv_string_to_dict(connstr)
     conn_dict["host"] = pgb_unit_address

--- a/tests/integration/bundle/test_tls_bundle.py
+++ b/tests/integration/bundle/test_tls_bundle.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from constants import TLS_APP_NAME
+from constants import PG, PGB, TLS_APP_NAME
 from tests.integration.helpers.helpers import deploy_postgres_k8s_bundle
 from tests.integration.helpers.postgresql_helpers import (
     enable_connections_logging,
@@ -21,8 +21,6 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 FINOS_WALTZ = "finos-waltz"
-PGB = METADATA["name"]
-PG = "postgresql-k8s"
 TLS = "tls-certificates-operator"
 RELATION = "backend-database"
 

--- a/tests/integration/bundle/test_tls_bundle.py
+++ b/tests/integration/bundle/test_tls_bundle.py
@@ -49,7 +49,7 @@ async def test_tls_encrypted_connection_to_postgres(ops_test: OpsTest):
     logs = await run_command_on_unit(
         ops_test, postgresql_primary_unit, "/charm/bin/pebble logs -n=all"
     )
+    username = f"{PGB}_user_{relation.id}_{ops_test.model.info.name}".replace("-", "_")
     assert (
-        f"connection authorized: user=relation_id_{relation.id} database=waltz"
-        " SSL enabled (protocol=TLSv1.2, cipher=ECDHE-RSA-AES256-GCM-SHA384, bits=256)" in logs
+        f"connection authorized: user={username} database=waltz SSL enabled" in logs
     ), "TLS is not being used on connections to PostgreSQL"

--- a/tests/integration/helpers/helpers.py
+++ b/tests/integration/helpers/helpers.py
@@ -9,18 +9,17 @@ from typing import Dict, Tuple
 
 from charms.pgbouncer_k8s.v0 import pgb
 from juju.relation import Relation
-from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from constants import AUTH_FILE_PATH, INI_PATH, PG, PGB, TLS_APP_NAME
 
 
-def get_leader(ops_test, application_name) -> Unit:
-    """Gets the leader unit for the given app name."""
+async def get_leader(ops_test, application_name) -> str:
+    """Gets the leader unit name for the given app name."""
     for unit in ops_test.model.applications[application_name].units:
-        if unit.is_leader_from_status():
-            return unit
+        if await unit.is_leader_from_status():
+            return unit.name
 
 
 def get_backend_relation(ops_test: OpsTest) -> Relation:
@@ -223,7 +222,7 @@ async def scale_application(ops_test: OpsTest, application_name: str, scale: int
         await ops_test.model.wait_for_idle(
             apps=[application_name],
             status="active",
-            timeout=600,
+            timeout=1000,
             wait_for_exact_units=scale,
         )
 

--- a/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
+++ b/tests/integration/relations/pgbouncer_provider/test_pgbouncer_provider.py
@@ -327,14 +327,12 @@ async def test_multiple_pgb_can_connect_to_one_backend(ops_test: OpsTest):
         channel="edge",
         application_name=pgb_secondary,
     )
-    async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=[pgb_secondary], status="active"),
 
     await ops_test.model.add_relation(f"{pgb_secondary}:{BACKEND_RELATION_NAME}", f"{PG}:database")
     wait_for_relation_joined_between(ops_test, PG, pgb_secondary)
 
     async with ops_test.fast_forward():
-        await ops_test.model.wait_for_idle(apps=APP_NAMES + [pgb_secondary])
+        await ops_test.model.wait_for_idle(apps=APP_NAMES + [pgb_secondary], status="active")
 
     secondary_relation = await ops_test.model.add_relation(
         f"{SECONDARY_CLIENT_APP_NAME}:{SECOND_DATABASE_RELATION_NAME}", pgb_secondary

--- a/tests/integration/relations/test_backend_database.py
+++ b/tests/integration/relations/test_backend_database.py
@@ -48,7 +48,10 @@ async def test_deploy_bundle(ops_test: OpsTest):
         pgb_unit = ops_test.model.applications[PGB].units[0]
         logging.info(await get_app_relation_databag(ops_test, pgb_unit.name, backend_relation.id))
         wait_for_relation_removed_between(ops_test, PG, PGB)
-        await ops_test.model.wait_for_idle(apps=[PG, PGB], status="active", timeout=600),
+        await asyncio.gather(
+            ops_test.model.wait_for_idle(apps=[PG], status="active", timeout=600),
+            ops_test.model.wait_for_idle(apps=[PGB], status="blocked", timeout=600),
+        )
 
         # Wait for pgbouncer charm to update its config files.
         try:


### PR DESCRIPTION
## Proposal
Avoid confusing on `charmcraft list-lib` output (due to wrong name in metadata.yaml):
```
>> charmcraft list-lib
> Library name    API    Patch
> postgresql      0      7
> postgresql_tls  0      4
```

## Release Notes
Fix bundle name in metadata.yaml.

## Testing
Testing on GH Actions.