### PR TITLE
[MISC] Switch tests to juju 3.5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,26 +7,8 @@
     {
       "matchPackageNames": ["pydantic"],
       "allowedVersions": "<2.0.0"
-    }, {
-      "matchDepNames": ["Juju 3"],
-      "matchPackageNames": ["juju/juju"],
-      "allowedVersions": "<3.2.0",
-      "extractVersion": "^v(?<version>.*)$",
-      "groupName": "Juju 3"
     }
   ],
   "regexManagers": [
-    {
-      "customType": "regex",
-      "fileMatch": ["^(workflow-templates|\\.github/workflows)/[^/]+\\.ya?ml$"],
-      "matchStrings": [
-        "(- agent: )(?<currentValue>.*?) +# renovate: latest juju 3"
-      ],
-      "depNameTemplate": "Juju 3",
-      "packageNameTemplate": "juju/juju",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "loose",
-      "extractVersionTemplate": "Juju release"
-    }
   ]
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         juju:
-          - agent: 3.1.8  # renovate: latest juju 3
+          - agent: 3.5.1  # renovate: juju-agent-pin-minor
+            juju-snap-channel: 3.5/stable
             allure_on_amd64: true
         architecture:
           - amd64
@@ -41,7 +42,7 @@ jobs:
       artifact-prefix: packed-charm-
       architecture: ${{ matrix.architecture }}
       cloud: microk8s
-      microk8s-snap-channel: 1.29-strict/stable
+      microk8s-snap-channel: 1.29-strict/stable  # renovate: latest microk8s
       juju-agent-version: ${{ matrix.juju.agent }}
       _beta_allure_report: ${{ matrix.juju.allure_on_amd64 && matrix.architecture == 'amd64' }}
     permissions:


### PR DESCRIPTION
Since charms run tests of 2.9 and 3.1, we can use the bundle to smoke test things on latest stable.