### PR TITLE
[DPE-4627] Bump update-bundle workflow version to v16.3.2

### DIFF
--- a/.github/workflows/update_bundle.yaml
+++ b/.github/workflows/update_bundle.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   update-bundle:
     name: Update bundle
-    uses: canonical/data-platform-workflows/.github/workflows/update_bundle.yaml@v16.3.0
+    uses: canonical/data-platform-workflows/.github/workflows/update_bundle.yaml@v16.3.2
     with:
       path-to-bundle-file: releases/latest/postgresql-k8s-bundle.yaml
       reviewers: canonical/data-platform-postgresql


### PR DESCRIPTION
## Issue

https://warthogs.atlassian.net/browse/DPE-4627

## Solution

Fixed by https://github.com/canonical/data-platform-workflows/pull/207