### PR TITLE
[DPE-6042] Make tox commands resilient to white-space paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,13 +7,13 @@ skip_missing_interpreters = True
 env_list = lint, unit
 
 [vars]
-src_path = {tox_root}/src
-tests_path = {tox_root}/tests
+src_path = "{tox_root}/src"
+tests_path = "{tox_root}/tests"
 all_path = {[vars]src_path} {[vars]tests_path}
 
 [testenv]
 set_env =
-    PYTHONPATH = {tox_root}:{tox_root}/lib:{[vars]src_path}
+    PYTHONPATH = {tox_root}:{tox_root}/lib:{tox_root}/src
     PY_COLORS = 1
 allowlist_externals =
     poetry


### PR DESCRIPTION
This PR fixes [tox.ini](https://github.com/canonical/postgresql-k8s-bundle/blob/main/tox.ini) commands when the repository is cloned on a white-space containing path.

### How to reproduce:
```shell
$ mkdir -p "Projects/Canonical/Data Platform/PostgreSQL"
$ cd "Projects/Canonical/Data Platform/PostgreSQL"
$ git clone https://github.com/canonical/postgresql-k8s-bundle
$ cd postgresql-k8s-bundle
$ tox run -e format
> ...
> /Users/<USERNAME>/Projects/Canonical/Data:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/postgresql-k8s-bundle/src:1:1: E902 No such file or directory (os error 2)
> Platform/PostgreSQL/postgresql-k8s-bundle/tests:1:1: E902 No such file or directory (os error 2)

```

### Additional considerations
Using the quoted paths to set up the `PYTHONPATH` does not work. This can be tested by running the unit tests.