### PR TITLE
DPE-8975 Move K8s bundle TLS to 1/stable

### DIFF
--- a/releases/latest/postgresql-k8s-bundle.yaml
+++ b/releases/latest/postgresql-k8s-bundle.yaml
@@ -53,7 +53,7 @@ applications:
     revision: 188
     scale: 1
   self-signed-certificates:
-    channel: latest/edge
+    channel: 1/edge
     charm: self-signed-certificates
     constraints: arch=amd64
     num_units: 1

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -9,7 +9,7 @@ This is a Terraform module facilitating the deployment of Charmed Postgresql K8s
 | Name | Description | Type | Default | Required |
 | - | - | - | - | - |
 | `arch` | Architecture of the deployed model | `string` | `"amd64"` | no |
-| `certificates_charm_channel` | Channel for certificates charm | `string` | `"latest/stable"` | no |
+| `certificates_charm_channel` | Channel for certificates charm | `string` | `"1/stable"` | no |
 | `certificates_charm_config` | Configuration options for the certificates charm | `map(string)` | `{ca-common-name = "MySQL CA"}` | no |
 | `certificates_charm_name` | Name of the certificates charm to use | `string` | `"self-signed-certificates"` | no |
 | `certificates_charm_revision` | Charm revision number override for self-signed-certificates | `number` | `null` | no |

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -116,7 +116,7 @@ variable "s3_integrator_charm_channel" {
 variable "certificates_charm_channel" {
   description = "Certificates Operator charm channel"
   type        = string
-  default     = "latest/stable"
+  default     = "1/stable"
 }
 
 variable "postgresql_charm_revision" {


### PR DESCRIPTION
## Issue

self-signed-certificates latest/stable has been deprecated and replaced with 1/stable.

## Solution

Use 1/stable for bundle/Terraform.